### PR TITLE
Performance improvements in leap_HMC

### DIFF
--- a/matlab/LAHMC.m
+++ b/matlab/LAHMC.m
@@ -228,11 +228,8 @@ function [state] = leap_HMC(state,ind,opts,varargin)
     for ii=1:M
         funcevals_inc = funcevals_inc + Nind;
         
-        V0 = V;
-        X0 = X;
-        dEdX0 = dEdX;
-        Vhalf = V0 - epsilon/2 * dEdX0;
-        X1 = X0 + epsilon * Vhalf;
+        Vhalf = V - epsilon/2 * dEdX;
+        X1 = X + epsilon * Vhalf;
         dEdX1 = f_dEdX( X1, varargin{:} );
         V1 = Vhalf - epsilon/2 * dEdX1;
 


### PR DESCRIPTION
I restructured the leapfrog loop to avoid repeating the indexing of the particles to update.
This improves performance for me by around 30-40% (with default parameters M=10 T=100).
